### PR TITLE
FS-898 - Locust configurable running variables & fix to stop performance tests skipping in the pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
+        run: ls && python -m pip install locust && python -m locust --users $users --spawn-rate $spawn-rate --run-time $run-time --headless $headless
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,6 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
-    if:  ${{ always() && (needs.deploy_test=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test
@@ -214,6 +213,7 @@ jobs:
           retention-days: 5
           
   run_performance_tests:
+    if:  ${{ always() && (needs.deploy_test.result=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   
-    env:
-          users: 3
-          spawn-rate: 1
-          run-time: 10s
-          headless: true
+env:
+  users: 3
+  spawn-rate: 1
+  run-time: 10s
+  headless: true
+  
 jobs:
   testing-unit: 
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
         default: false
         type: boolean
       users:
-        required: true
+        required: false
         default: 3
         type: string
       spawn-rate: 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,7 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
-    if:  ${{ always() && (needs.deploy_test=='success') }}
+    if:  ${{ always() && (needs.deploy_test.result=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,12 @@ on:
         required: true
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
+  
+    env:
+          users: 3
+          spawn-rate: 1
+          run-time: 10s
+          headless: true
 jobs:
   testing-unit: 
     runs-on: ubuntu-latest
@@ -45,7 +50,7 @@ jobs:
         # pytest -m "not accessibility" runs every test which is not marked 
         # accessibility.
         run: python -m pip install pytest && python -m pytest -m "not accessibility" .
-
+  
   testing:
     runs-on: ubuntu-latest
     environment: Dev
@@ -208,11 +213,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        env:
-          users: 3
-          spawn-rate: 1
-          run-time: 1s
-        run: ls && python -m pip install locust && python -m locust
+        run: ls && python -m pip install locust && python -m locust --users $users --spawn-rate $spawn-rate --run-time $run-time --headless $headless
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
+        run: ls && python -m pip install locust && python -m locust --users --spawn-rate --run-time --headless
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,6 @@ on:
         required: false
         default: 10s
         type: string  
-      headless: 
-        required: false
-        default: true
-        type: boolean
         
     secrets:
       CF_API:
@@ -49,7 +45,6 @@ env:
   users: 1
   spawn-rate: 1
   run-time: 10s
-  headless: true
   
 jobs:
   testing-unit: 
@@ -232,7 +227,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inpusts.run-time}} --headless ${{inputs.headless}}
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,7 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
+    if:  ${{ always() && (needs.deploy_test=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test
@@ -213,7 +214,6 @@ jobs:
           retention-days: 5
           
   run_performance_tests:
-    if:  ${{ always() && (needs.deploy_test.result=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test
@@ -232,7 +232,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users $users --spawn-rate $spawn-rate --run-time $run-time --headless $headless
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,23 @@ on:
         required: false
         default: false
         type: boolean
+      users:
+        required: false
+        default: 3
+        type: string
+      spawn-rate: 
+        required: false
+        default: 1
+        type: string
+      run-time: 
+        required: false
+        default: 10s
+        type: string  
+      headless: 
+        required: false
+        default: true
+        type: boolean
+        
     secrets:
       CF_API:
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,7 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
-    if:  ${{ always() && (needs.deploy_test='success')}}
+    if:  ${{ always() && (needs.deploy_test=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
         default: false
         type: boolean
       users:
-        required: false
+        required: true
         default: 3
         type: string
       spawn-rate: 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,6 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
-    if:  ${{ always() && (needs.deploy_test.result=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test
@@ -214,6 +213,7 @@ jobs:
           retention-days: 5
           
   run_performance_tests:
+    if:  ${{ always() && (needs.deploy_test.result=='success') }}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,7 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
+    if:  ${{ always() && (needs.deploy_test='success'}}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users --spawn-rate --run-time --headless
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}} --headless ${{inputs.headless}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
       users:
         required: false
-        default: 3
+        default: 1
         type: string
       spawn-rate: 
         required: false
@@ -46,7 +46,7 @@ on:
   workflow_dispatch:
   
 env:
-  users: 3
+  users: 1
   spawn-rate: 1
   run-time: 10s
   headless: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,8 +207,11 @@ jobs:
         run: python -m venv .venv
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
-
       - name: Run performance tests
+        env:
+          users: 3
+          spawn-rate: 1
+          run-time: 1s
         run: ls && python -m pip install locust && python -m locust
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
       - name: install dependencies
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust --users $users --spawn-rate $spawn-rate --run-time $run-time --headless $headless
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inpusts.run-time}} --headless ${{inputs.headless}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,7 @@ jobs:
           command: push ${{inputs.app_name}}-test
 
   run_accessability_tests:
-    if:  ${{ always() && (needs.deploy_test='success'}}
+    if:  ${{ always() && (needs.deploy_test='success')}}
     needs: deploy_test
     runs-on: ubuntu-latest
     environment: test


### PR DESCRIPTION
Jira Ticket:
https://digital.dclg.gov.uk/jira/browse/FS-898

I have added environment variables which are basically configs from Locust. 

This will enable us to override these configs in each API store (fund, round and application) to help perform capacity testing. 

I have also added a condition in the run_performance_tests job as the performance tests were skipping in each of the API stores' pipelines. 

