### PR TITLE
Only deploy main branch to test environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
           allow_issue_writing: False
 
   deploy_test:
-    if: ${{ always() && (needs.testing-unit.result=='success' || needs.testing.result=='success') }}
+    if: ${{ always() && (needs.testing-unit.result=='success' || needs.testing.result=='success') && github.ref == 'refs/heads/main' }}
     needs: deploy_dev
     runs-on: ubuntu-latest
     environment: test


### PR DESCRIPTION
This would mean as-is the performance tests and accessibility tests would only run on the main branch I believe