### PR TITLE
FS-1677: pass through git sha to app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,7 @@ jobs:
           cf_space:    ${{secrets.CF_SPACE }}
           cf_username: ${{secrets.CF_USER}}
           cf_password: ${{secrets.CF_PASSWORD}}
-          command: push ${{inputs.app_name}}-dev
+          command: push ${{inputs.app_name}}-dev --var GITHUB_SHA="${{ github.sha }}"
 
   static_security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass through git sha in shared workflow, for use by Sentry release automation.