### PR TITLE
BAU-allow-newest-python3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: run unit tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: run unit tests
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: build static assets
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install bandit safety
       - name: Bandit
@@ -205,7 +205,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -238,7 +238,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt bandit safety
       - name: Bandit
@@ -264,7 +264,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -300,7 +300,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.1
+          python-version: 3.x
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies


### PR DESCRIPTION
Workflows will use the most up to date python3 version instead of being frozen at 3.10.1.

Requirements.txt will contain the version locked dependancies so this will allow for additional python features and bugfixes to be used.