### PR TITLE
bau-pip-dep-caching.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: run unit tests
@@ -113,6 +114,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: run unit tests
@@ -130,6 +132,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
       - name: build static assets
@@ -155,6 +158,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -187,6 +191,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install bandit safety
       - name: Bandit
@@ -206,6 +211,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -239,6 +245,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements.txt bandit safety
       - name: Bandit
@@ -265,6 +272,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies
@@ -301,6 +309,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+          cache: 'pip'
       - name: create python env
         run: python -m venv .venv
       - name: install dependencies


### PR DESCRIPTION
- Adds the cache line to set up python which allows for caching of python dependancies with no added overhead. (it uses a hash of requirements.txt to figure out when to refresh the cache).


> _Imagine a world where you don't have to wait for the same dependancies to install every time you run an action...turns out you don't need to imagine - if you merge this PR..._