### PR TITLE
bug security cache.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,8 +195,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
-          cache: 'pip'
-          cache-dependency-path: 'requirements-dev.txt'
       - name: install dependencies
         run: python -m pip install --upgrade pip && python -m pip install bandit safety
       - name: Bandit


### PR DESCRIPTION
Security doesn't use a requirements file - so there's no need to cache one (and it breaks the pipeline).