### PR TITLE
Prevent tests from running on dependabot PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,7 +284,7 @@ jobs:
           allow_issue_writing: False
 
   run_shared_tests_test:
-    if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,7 +191,7 @@ jobs:
 
   run_shared_tests_dev:
     needs: deploy_dev
-    if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) }}
+    if: ${{ always() && (inputs.deploy_to_dev == true && needs.deploy_dev.result=='success' ) && github.actor != 'dependabot[bot]' }}
     uses: ./.github/workflows/run-shared-tests.yml
     with:
       perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,7 +225,7 @@ jobs:
 
   deploy_test:
     needs: run_shared_tests_dev
-    if: ${{ always() && needs.run_shared_tests_dev.result=='success' && (needs.testing-unit.result=='success' || needs.testing.result=='success' || needs.testing-unit-postgres.result == 'success')}} # && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && (inputs.deploy_to_dev == false || (inputs.deploy_to_dev == true && needs.run_shared_tests_dev.result=='success')) && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: test
     steps:
@@ -261,7 +261,7 @@ jobs:
   
   security-with-zap:
     needs: deploy_test
-    if: ${{ always() && needs.deploy_test.result=='success' && (needs.testing-unit.result=='success' || needs.testing.result=='success' || needs.testing-unit-postgres.result == 'success')}} # && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && needs.deploy_test.result=='success' && (needs.testing-unit.result=='success' || needs.testing.result=='success' || needs.testing-unit-postgres.result == 'success') && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: test
     steps:
@@ -284,7 +284,7 @@ jobs:
           allow_issue_writing: False
 
   run_shared_tests_test:
-    if: ${{ always() && needs.deploy_test.result=='success' && (needs.testing-unit.result=='success' || needs.testing.result=='success' || needs.testing-unit-postgres.result == 'success') && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && needs.deploy_test.result=='success' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/run-shared-tests.yml
     needs: deploy_test
     with:


### PR DESCRIPTION
Preventing tests from running on dependabot PRs as they don't have access to the secrets